### PR TITLE
build: configure Dependabot for Rust toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "rust-toolchain" # See documentation for possible values
+    directories:
+    - "/"
+    - "/operator-derive"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Updated package ecosystem to include rust-toolchain and added directories for Dependabot.