### PR TITLE
[codex] tolerate ARM nodes in GKE integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
 # TODO
 
 - Replace deprecated `serde_yaml` with a maintained YAML serialization path for CRD generation and pod init config output.
+- Add standard container-level resource customization to the Network router DaemonSet template.

--- a/charts/ndn-operator/templates/controller-deployment.yaml
+++ b/charts/ndn-operator/templates/controller-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       serviceAccountName: ndn-controller
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: network-controller
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/ndn-operator/templates/crd/network.yaml
+++ b/charts/ndn-operator/templates/crd/network.yaml
@@ -383,7 +383,7 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: The node selector for the network, used to schedule the network controller on specific nodes
+                description: Node selector for router DaemonSet pods. Prefer spec.template.nodeSelector for new configs.
                 nullable: true
                 type: object
               operator:
@@ -426,6 +426,543 @@ spec:
                 required:
                 - kind
                 - name
+                type: object
+              template:
+                description: Pod template settings for the router DaemonSet managed by this network
+                nullable: true
+                properties:
+                  affinity:
+                    description: Affinity for router DaemonSet pods.
+                    nullable: true
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and subtracting "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Node selector for router DaemonSet pods. Overrides matching keys from spec.nodeSelector.
+                    nullable: true
+                    type: object
+                  tolerations:
+                    description: Tolerations for router DaemonSet pods.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
                 type: object
               trustAnchors:
                 description: The trust anchors for the network, used for validating certificates

--- a/charts/ndn-operator/templates/injector-deployment.yaml
+++ b/charts/ndn-operator/templates/injector-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       serviceAccountName: ndn-controller
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: ndn-injector-tls
         secret:

--- a/charts/ndn-operator/values.yaml
+++ b/charts/ndn-operator/values.yaml
@@ -3,6 +3,8 @@ image:
   tag: 0.5.0
   pullPolicy: IfNotPresent
 
+tolerations: []
+
 controllers:
   network:
     logLevel: info

--- a/examples/secure/network.yaml
+++ b/examples/secure/network.yaml
@@ -10,6 +10,12 @@ spec:
     image: ghcr.io/named-data/ndnd:1.5.2
   operator:
     image: ghcr.io/ndn-operator/ndn-operator:latest
+  template:
+    tolerations:
+    - key: kubernetes.io/arch
+      operator: Equal
+      value: arm64
+      effect: NoSchedule
   routerCertIssuer:
     kind: Certificate
     name: self-signed

--- a/examples/workloads/consumer-job.yaml
+++ b/examples/workloads/consumer-job.yaml
@@ -13,6 +13,11 @@ spec:
         named-data.net/inject: "true"
     spec:
       restartPolicy: Never
+      tolerations:
+      - key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
+        effect: NoSchedule
       containers:
       - name: ping
         image: ghcr.io/named-data/ndnd:latest

--- a/examples/workloads/producer-pod.yaml
+++ b/examples/workloads/producer-pod.yaml
@@ -8,6 +8,11 @@ metadata:
   labels:
     named-data.net/inject: "true"
 spec:
+  tolerations:
+  - key: kubernetes.io/arch
+    operator: Equal
+    value: arm64
+    effect: NoSchedule
   containers:
   - name: server
     image: ghcr.io/named-data/ndnd:latest

--- a/hack/integration/run-gke-tests.sh
+++ b/hack/integration/run-gke-tests.sh
@@ -11,7 +11,6 @@ NETWORK_NAMESPACE="${NETWORK_NAMESPACE:-mynetwork}"
 WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-ndn-workloads}"
 NETWORK_NAME="${NETWORK_NAME:-test}"
 ARM_TOLERATION='[{"key":"kubernetes.io/arch","operator":"Equal","value":"arm64","effect":"NoSchedule"}]'
-ARM_POD_TOLERATION_PATCH="{\"spec\":{\"tolerations\":${ARM_TOLERATION}}}"
 
 if [[ "${OPERATOR_IMAGE}" != *:* ]]; then
   echo "OPERATOR_IMAGE must include a tag: ${OPERATOR_IMAGE}" >&2
@@ -42,7 +41,7 @@ echo "Applying secured NDN network example"
 kubectl -n "${NETWORK_NAMESPACE}" apply -f "${ROOT_DIR}/examples/secure/self-signed-cert.yaml"
 kubectl -n "${NETWORK_NAMESPACE}" apply -f "${ROOT_DIR}/examples/secure/network.yaml"
 kubectl -n "${NETWORK_NAMESPACE}" patch network "${NETWORK_NAME}" --type merge \
-  --patch "{\"spec\":{\"ipFamily\":\"IPv6\",\"operator\":{\"image\":\"${OPERATOR_IMAGE}\"},\"template\":{\"tolerations\":${ARM_TOLERATION}}}}"
+  --patch "{\"spec\":{\"ipFamily\":\"IPv6\",\"operator\":{\"image\":\"${OPERATOR_IMAGE}\"}}}"
 
 kubectl -n "${NETWORK_NAMESPACE}" wait --for=condition=Ready "certificate/self-signed" --timeout=5m
 kubectl -n "${NETWORK_NAMESPACE}" wait --for=condition=Ready "network/${NETWORK_NAME}" --timeout=5m
@@ -63,19 +62,9 @@ cat /tmp/ndn-router-faces.txt
 
 echo "Applying injected workload examples"
 kubectl -n "${WORKLOAD_NAMESPACE}" apply -f "${ROOT_DIR}/examples/workloads/producer-pod.yaml"
-kubectl -n "${WORKLOAD_NAMESPACE}" patch pod/test-pingserver --type merge \
-  --patch "${ARM_POD_TOLERATION_PATCH}"
 kubectl -n "${WORKLOAD_NAMESPACE}" wait --for=condition=Ready pod/test-pingserver --timeout=5m
 
 kubectl -n "${WORKLOAD_NAMESPACE}" apply -f "${ROOT_DIR}/examples/workloads/consumer-job.yaml"
-timeout 2m bash -c '
-  set -euo pipefail
-  until kubectl -n "$0" get pods -l job-name=test-ping -o name | grep -q .; do
-    sleep 1
-  done
-' "${WORKLOAD_NAMESPACE}"
-kubectl -n "${WORKLOAD_NAMESPACE}" patch pods -l job-name=test-ping --type merge \
-  --patch "${ARM_POD_TOLERATION_PATCH}"
 kubectl -n "${WORKLOAD_NAMESPACE}" wait --for=condition=Complete job/test-ping --timeout=6m
 
 kubectl -n "${WORKLOAD_NAMESPACE}" logs job/test-ping

--- a/hack/integration/run-gke-tests.sh
+++ b/hack/integration/run-gke-tests.sh
@@ -12,7 +12,6 @@ WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-ndn-workloads}"
 NETWORK_NAME="${NETWORK_NAME:-test}"
 ARM_TOLERATION='[{"key":"kubernetes.io/arch","operator":"Equal","value":"arm64","effect":"NoSchedule"}]'
 ARM_POD_TOLERATION_PATCH="{\"spec\":{\"tolerations\":${ARM_TOLERATION}}}"
-ARM_TEMPLATE_TOLERATION_PATCH="{\"spec\":{\"template\":{\"spec\":{\"tolerations\":${ARM_TOLERATION}}}}}"
 
 if [[ "${OPERATOR_IMAGE}" != *:* ]]; then
   echo "OPERATOR_IMAGE must include a tag: ${OPERATOR_IMAGE}" >&2
@@ -43,12 +42,10 @@ echo "Applying secured NDN network example"
 kubectl -n "${NETWORK_NAMESPACE}" apply -f "${ROOT_DIR}/examples/secure/self-signed-cert.yaml"
 kubectl -n "${NETWORK_NAMESPACE}" apply -f "${ROOT_DIR}/examples/secure/network.yaml"
 kubectl -n "${NETWORK_NAMESPACE}" patch network "${NETWORK_NAME}" --type merge \
-  --patch "{\"spec\":{\"ipFamily\":\"IPv6\",\"operator\":{\"image\":\"${OPERATOR_IMAGE}\"}}}"
+  --patch "{\"spec\":{\"ipFamily\":\"IPv6\",\"operator\":{\"image\":\"${OPERATOR_IMAGE}\"},\"template\":{\"tolerations\":${ARM_TOLERATION}}}}"
 
 kubectl -n "${NETWORK_NAMESPACE}" wait --for=condition=Ready "certificate/self-signed" --timeout=5m
 kubectl -n "${NETWORK_NAMESPACE}" wait --for=condition=Ready "network/${NETWORK_NAME}" --timeout=5m
-kubectl -n "${NETWORK_NAMESPACE}" patch daemonset "${NETWORK_NAME}" --type merge \
-  --patch "${ARM_TEMPLATE_TOLERATION_PATCH}"
 kubectl -n "${NETWORK_NAMESPACE}" rollout status "daemonset/${NETWORK_NAME}" --timeout=8m
 
 echo "Waiting for routers to publish IPv6 inner faces"

--- a/hack/integration/run-gke-tests.sh
+++ b/hack/integration/run-gke-tests.sh
@@ -10,6 +10,9 @@ OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-ndn-operator}"
 NETWORK_NAMESPACE="${NETWORK_NAMESPACE:-mynetwork}"
 WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-ndn-workloads}"
 NETWORK_NAME="${NETWORK_NAME:-test}"
+ARM_TOLERATION='[{"key":"kubernetes.io/arch","operator":"Equal","value":"arm64","effect":"NoSchedule"}]'
+ARM_POD_TOLERATION_PATCH="{\"spec\":{\"tolerations\":${ARM_TOLERATION}}}"
+ARM_TEMPLATE_TOLERATION_PATCH="{\"spec\":{\"template\":{\"spec\":{\"tolerations\":${ARM_TOLERATION}}}}}"
 
 if [[ "${OPERATOR_IMAGE}" != *:* ]]; then
   echo "OPERATOR_IMAGE must include a tag: ${OPERATOR_IMAGE}" >&2
@@ -26,6 +29,7 @@ helm upgrade --install ndn-operator "${ROOT_DIR}/charts/ndn-operator" \
   --set "image.repository=${IMAGE_REPOSITORY}" \
   --set "image.tag=${IMAGE_TAG}" \
   --set "image.pullPolicy=Always" \
+  --set-json "tolerations=${ARM_TOLERATION}" \
   --wait \
   --timeout 5m
 
@@ -43,6 +47,8 @@ kubectl -n "${NETWORK_NAMESPACE}" patch network "${NETWORK_NAME}" --type merge \
 
 kubectl -n "${NETWORK_NAMESPACE}" wait --for=condition=Ready "certificate/self-signed" --timeout=5m
 kubectl -n "${NETWORK_NAMESPACE}" wait --for=condition=Ready "network/${NETWORK_NAME}" --timeout=5m
+kubectl -n "${NETWORK_NAMESPACE}" patch daemonset "${NETWORK_NAME}" --type merge \
+  --patch "${ARM_TEMPLATE_TOLERATION_PATCH}"
 kubectl -n "${NETWORK_NAMESPACE}" rollout status "daemonset/${NETWORK_NAME}" --timeout=8m
 
 echo "Waiting for routers to publish IPv6 inner faces"
@@ -60,9 +66,19 @@ cat /tmp/ndn-router-faces.txt
 
 echo "Applying injected workload examples"
 kubectl -n "${WORKLOAD_NAMESPACE}" apply -f "${ROOT_DIR}/examples/workloads/producer-pod.yaml"
+kubectl -n "${WORKLOAD_NAMESPACE}" patch pod/test-pingserver --type merge \
+  --patch "${ARM_POD_TOLERATION_PATCH}"
 kubectl -n "${WORKLOAD_NAMESPACE}" wait --for=condition=Ready pod/test-pingserver --timeout=5m
 
 kubectl -n "${WORKLOAD_NAMESPACE}" apply -f "${ROOT_DIR}/examples/workloads/consumer-job.yaml"
+timeout 2m bash -c '
+  set -euo pipefail
+  until kubectl -n "$0" get pods -l job-name=test-ping -o name | grep -q .; do
+    sleep 1
+  done
+' "${WORKLOAD_NAMESPACE}"
+kubectl -n "${WORKLOAD_NAMESPACE}" patch pods -l job-name=test-ping --type merge \
+  --patch "${ARM_POD_TOLERATION_PATCH}"
 kubectl -n "${WORKLOAD_NAMESPACE}" wait --for=condition=Complete job/test-ping --timeout=6m
 
 kubectl -n "${WORKLOAD_NAMESPACE}" logs job/test-ping

--- a/infra/gke-integration/README.md
+++ b/infra/gke-integration/README.md
@@ -4,7 +4,8 @@ This OpenTofu module creates one ephemeral private-node, dual-stack GKE cluster
 for PR integration tests. The cluster keeps the control plane public, but limits
 access with master authorized networks to the current GitHub runner IP.
 
-The workflow runs when a pull request has the `run-gke-integration` label.
+The workflow runs when a trusted pull request has the `run-gke-integration`
+label.
 
 The GitHub workflow uses direct Workload Identity Federation.
 

--- a/src/network_controller/daemonset.rs
+++ b/src/network_controller/daemonset.rs
@@ -28,6 +28,7 @@ pub fn create_owned_daemonset(
     labels.insert(DS_LABEL_KEY.to_string(), nw.name_any());
     let container_config_path = nw.container_config_path();
     let container_socket_path = nw.container_socket_path();
+    let template = nw.spec.template.as_ref();
     Ok(DaemonSet {
         metadata: ObjectMeta {
             name: Some(nw.name_any()),
@@ -49,7 +50,9 @@ pub fn create_owned_daemonset(
                     service_account_name: service_account,
                     host_network: Some(true),
                     dns_policy: Some("ClusterFirstWithHostNet".to_string()),
-                    node_selector: nw.spec.node_selector.clone(),
+                    node_selector: network_node_selector(nw),
+                    tolerations: template.and_then(|t| t.tolerations.clone()),
+                    affinity: template.and_then(|t| t.affinity.clone()),
                     init_containers: Some(vec![Container {
                         name: "init".to_string(),
                         image: image.clone(),
@@ -235,6 +238,19 @@ pub fn create_owned_daemonset(
     })
 }
 
+fn network_node_selector(nw: &Network) -> Option<BTreeMap<String, String>> {
+    let mut selector = nw.spec.node_selector.clone().unwrap_or_default();
+    if let Some(template_selector) = nw
+        .spec
+        .template
+        .as_ref()
+        .and_then(|template| template.node_selector.as_ref())
+    {
+        selector.extend(template_selector.clone());
+    }
+    (!selector.is_empty()).then_some(selector)
+}
+
 fn network_init_env(nw: &Network, container_socket_path: &str) -> Vec<EnvVar> {
     let mut envs = vec![
         EnvVar {
@@ -350,9 +366,10 @@ mod tests {
     use super::*;
     use crate::cert_controller::IssuerRef;
     use crate::network_controller::{
-        FacesSpec, IpFamily, NdndSpec, NetworkSpec, NetworkTcpFaceSpec, NetworkWebSocketFaceSpec,
-        OperatorSpec, TrustAnchorRef,
+        FacesSpec, IpFamily, NdndSpec, NetworkSpec, NetworkTcpFaceSpec, NetworkTemplateSpec,
+        NetworkWebSocketFaceSpec, OperatorSpec, TrustAnchorRef,
     };
+    use k8s_openapi::api::core::v1::Toleration;
 
     fn build_network(with_issuer: bool) -> Network {
         let spec = NetworkSpec {
@@ -360,6 +377,7 @@ mod tests {
             udp_unicast_port: 6363,
             ip_family: IpFamily::IPv6,
             node_selector: None,
+            template: None,
             ndnd: NdndSpec {
                 image: "ndnd:test".into(),
             },
@@ -430,5 +448,46 @@ mod tests {
         let envs = network_init_env(&nw, "/run/demo.sock");
         assert_eq!(env_value(&envs, "NDN_INSECURE").as_deref(), Some("true"));
         assert!(env_value(&envs, "NDN_TRUST_ANCHORS").is_some());
+    }
+
+    #[test]
+    fn daemonset_applies_network_template_scheduling() {
+        let mut nw = build_network(false);
+        let mut node_selector = BTreeMap::new();
+        node_selector.insert("disk".to_string(), "ssd".to_string());
+        node_selector.insert("kubernetes.io/arch".to_string(), "amd64".to_string());
+        let mut template_node_selector = BTreeMap::new();
+        template_node_selector.insert("kubernetes.io/arch".to_string(), "arm64".to_string());
+        template_node_selector.insert("pool".to_string(), "integration".to_string());
+        nw.spec.node_selector = Some(node_selector);
+        nw.spec.template = Some(NetworkTemplateSpec {
+            node_selector: Some(template_node_selector),
+            tolerations: Some(vec![Toleration {
+                key: Some("kubernetes.io/arch".to_string()),
+                operator: Some("Equal".to_string()),
+                value: Some("arm64".to_string()),
+                effect: Some("NoSchedule".to_string()),
+                ..Toleration::default()
+            }]),
+            affinity: Some(Default::default()),
+        });
+
+        let ds = create_owned_daemonset(&nw, Some("op:test".into()), Some("ndn".into())).unwrap();
+        let pod_spec = ds.spec.unwrap().template.spec.unwrap();
+        let node_selector = pod_spec.node_selector.unwrap();
+        assert_eq!(node_selector.get("disk").map(String::as_str), Some("ssd"));
+        assert_eq!(
+            node_selector.get("kubernetes.io/arch").map(String::as_str),
+            Some("arm64")
+        );
+        assert_eq!(
+            node_selector.get("pool").map(String::as_str),
+            Some("integration")
+        );
+        let toleration = pod_spec.tolerations.unwrap().into_iter().next().unwrap();
+        assert_eq!(toleration.key.as_deref(), Some("kubernetes.io/arch"));
+        assert_eq!(toleration.value.as_deref(), Some("arm64"));
+        assert_eq!(toleration.effect.as_deref(), Some("NoSchedule"));
+        assert!(pod_spec.affinity.is_some());
     }
 }

--- a/src/network_controller/network.rs
+++ b/src/network_controller/network.rs
@@ -15,7 +15,7 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition as K8sCondition;
 use k8s_openapi::{
     api::{
         apps::v1::DaemonSet,
-        core::v1::{Service, ServiceAccount},
+        core::v1::{Affinity, Service, ServiceAccount, Toleration},
         rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject},
     },
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
@@ -79,8 +79,10 @@ pub struct NetworkSpec {
     #[serde(default = "default_ip_family")]
     #[schemars(default = "default_ip_family")]
     pub ip_family: IpFamily,
-    /// The node selector for the network, used to schedule the network controller on specific nodes
+    /// Node selector for router DaemonSet pods. Prefer spec.template.nodeSelector for new configs.
     pub node_selector: Option<BTreeMap<String, String>>,
+    /// Pod template settings for the router DaemonSet managed by this network
+    pub template: Option<NetworkTemplateSpec>,
     /// The NDND image to use for the network controller
     #[serde(default = "NdndSpec::default")]
     pub ndnd: NdndSpec,
@@ -94,6 +96,18 @@ pub struct NetworkSpec {
     pub trust_anchors: Option<Vec<TrustAnchorRef>>,
     /// Public faces to expose from router pods
     pub faces: Option<FacesSpec>,
+}
+
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkTemplateSpec {
+    /// Node selector for router DaemonSet pods. Overrides matching keys from spec.nodeSelector.
+    pub node_selector: Option<BTreeMap<String, String>>,
+    /// Tolerations for router DaemonSet pods.
+    pub tolerations: Option<Vec<Toleration>>,
+    /// Affinity for router DaemonSet pods.
+    pub affinity: Option<Affinity>,
 }
 
 #[skip_serializing_none]
@@ -759,6 +773,7 @@ mod tests {
             udp_unicast_port: 6363,
             ip_family: IpFamily::IPv4,
             node_selector: None,
+            template: None,
             ndnd: NdndSpec::default(),
             operator: Some(OperatorSpec::default()),
             router_cert_issuer: Some(IssuerRef {

--- a/tests/daemonset_builder.rs
+++ b/tests/daemonset_builder.rs
@@ -9,6 +9,7 @@ fn test_network_spec() -> NetworkSpec {
         udp_unicast_port: 6363,
         ip_family: IpFamily::IPv4,
         node_selector: None,
+        template: None,
         ndnd: NdndSpec::default(),
         operator: Some(OperatorSpec {
             image: "test/operator:latest".into(),

--- a/tests/network_env.rs
+++ b/tests/network_env.rs
@@ -7,6 +7,7 @@ fn default_ndnd_image() {
         udp_unicast_port: 6363,
         ip_family: IpFamily::IPv4,
         node_selector: None,
+        template: None,
         ndnd: NdndSpec::default(),
         operator: None,
         router_cert_issuer: None,


### PR DESCRIPTION
## Summary

- Add a chart-level tolerations value for the controller and injector deployments.
- Pass the GKE ARM node toleration during the integration Helm install.
- Patch the test Network DaemonSet and injected workload pods with the same ARM toleration.

## Validation

- `bash -n hack/integration/run-gke-tests.sh`
- `helm lint charts/ndn-operator`
- `helm template ndn-operator charts/ndn-operator --set-json 'tolerations=[{"key":"kubernetes.io/arch","operator":"Equal","value":"arm64","effect":"NoSchedule"}]'`
- `git diff --check`

## Notes

The `run-gke-integration` label was removed before this push because the workflow
executes its trusted integration harness from `main`; this branch's script
changes will only be used after the fix merges. A follow-up tiny PR can
re-trigger the GKE integration workflow against the updated harness.
