### PR TITLE
[codex] test GKE integration workflow

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -221,6 +221,7 @@ jobs:
       TF_VAR_project_id: ${{ vars.GKE_INTEGRATION_PROJECT_ID }}
       TF_VAR_region: ${{ vars.GKE_INTEGRATION_REGION || 'us-west1' }}
       TF_VAR_location: ${{ vars.GKE_INTEGRATION_LOCATION || 'us-west1-a' }}
+      TF_VAR_machine_type: ${{ vars.GKE_INTEGRATION_MACHINE_TYPE || 'n4a-standard-2' }}
       TF_VAR_name: ndn-it-${{ github.event.pull_request.number }}-${{ github.run_id }}
       TF_VAR_pr_number: ${{ github.event.pull_request.number }}
       TF_VAR_run_id: ${{ github.run_id }}

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -210,7 +210,7 @@ jobs:
     environment: gke-integration
     concurrency:
       group: gke-integration-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -299,6 +299,19 @@ jobs:
         OPERATOR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
         REPO_UNDER_TEST_DIR: ${{ github.workspace }}/under-test
       run: trusted/hack/integration/run-gke-tests.sh
+    - name: Refresh Google Cloud auth before artifacts
+      if: always() && steps.credentials.outcome == 'success'
+      uses: google-github-actions/auth@v3
+      with:
+        project_id: ${{ vars.GKE_INTEGRATION_PROJECT_ID }}
+        workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+    - name: Refresh GKE credentials before artifacts
+      if: always() && steps.credentials.outcome == 'success'
+      uses: google-github-actions/get-gke-credentials@v3
+      with:
+        project_id: ${{ vars.GKE_INTEGRATION_PROJECT_ID }}
+        cluster_name: ${{ steps.tofu-output.outputs.cluster_name }}
+        location: ${{ steps.tofu-output.outputs.cluster_location }}
     - name: Collect cluster artifacts
       if: always() && steps.credentials.outcome == 'success'
       env:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ helm repo update
 helm install ndn-operator ndn-operator/ndn-operator \
     --namespace ndn-operator --create-namespace
 ```
-## Create secured ndn network
+## Create a secured NDN network
 
 ### Namespace
 ```shell
@@ -33,7 +33,7 @@ kubectl apply --namespace mynetwork \
     -f https://raw.githubusercontent.com/ndn-operator/ndn-operator/refs/heads/main/examples/secure/network.yaml
 ```
 ### Pingserver
-Producers and consumers may live in different k8s namespaces from the network, and from each other
+Producers and consumers may live in different Kubernetes namespaces from the network, and from each other.
 * Producer:
 ```shell
 kubectl apply \

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 
 - Replace deprecated `serde_yaml` with a maintained YAML serialization path for CRD generation and pod init config output.
 - Add standard container-level resource customization to the Network router DaemonSet template.
+- Document the GKE integration workflow after the test automation settles.

--- a/hack/integration/run-gke-tests.sh
+++ b/hack/integration/run-gke-tests.sh
@@ -19,6 +19,7 @@ fi
 
 IMAGE_REPOSITORY="${OPERATOR_IMAGE%:*}"
 IMAGE_TAG="${OPERATOR_IMAGE##*:}"
+LOW_CPU_REQUEST=25m
 
 echo "Installing ndn-operator from ${OPERATOR_IMAGE}"
 helm upgrade --install ndn-operator "${ROOT_DIR}/charts/ndn-operator" \
@@ -27,6 +28,13 @@ helm upgrade --install ndn-operator "${ROOT_DIR}/charts/ndn-operator" \
   --set "image.repository=${IMAGE_REPOSITORY}" \
   --set "image.tag=${IMAGE_TAG}" \
   --set "image.pullPolicy=Always" \
+  --set "controllers.network.resources.requests.cpu=${LOW_CPU_REQUEST}" \
+  --set "controllers.router.resources.requests.cpu=${LOW_CPU_REQUEST}" \
+  --set "controllers.neighbor.resources.requests.cpu=${LOW_CPU_REQUEST}" \
+  --set "controllers.pod.resources.requests.cpu=${LOW_CPU_REQUEST}" \
+  --set "controllers.certificate.resources.requests.cpu=${LOW_CPU_REQUEST}" \
+  --set "controllers.externalCertificate.resources.requests.cpu=${LOW_CPU_REQUEST}" \
+  --set "injector.resources.requests.cpu=${LOW_CPU_REQUEST}" \
   --set-json "tolerations=${ARM_TOLERATION}" \
   --wait \
   --timeout 5m

--- a/infra/gke-integration/README.md
+++ b/infra/gke-integration/README.md
@@ -23,6 +23,7 @@ Optional repository variables:
 
 - `GKE_INTEGRATION_REGION`: defaults to `us-west1`.
 - `GKE_INTEGRATION_LOCATION`: defaults to `us-west1-a`.
+- `GKE_INTEGRATION_MACHINE_TYPE`: defaults to `n4a-standard-2`.
 
 The direct WIF principal needs enough access to create and delete the test
 cluster and its network. A practical starting point is:


### PR DESCRIPTION
## Summary

- Touch README wording in the secured network example section.
- Add a TODO item for documenting the GKE integration workflow after the automation settles.
- Use 2-vCPU ARM nodes by default for GKE integration, with a repo variable override.
- Reduce GKE integration Helm CPU requests for the operator pods once this harness change is trusted from main.
- Refresh GCP/GKE credentials before artifact collection and prevent newer GKE runs from canceling teardown in progress.

## Why

This PR exercises and fixes the label-triggered GKE integration workflow after the ARM scheduling changes merged. The first run showed the controller pod could not fit on the 1-vCPU ARM nodes because it requested 600m CPU as a single multi-container pod.

## Validation

- git diff --check
- bash -n hack/integration/run-gke-tests.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-push.yaml")'
- helm lint charts/ndn-operator