### PR TITLE
[codex] rerun GKE integration workflow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,3 +3,4 @@
 - Replace deprecated `serde_yaml` with a maintained YAML serialization path for CRD generation and pod init config output.
 - Add standard container-level resource customization to the Network router DaemonSet template.
 - Document the GKE integration workflow after the test automation settles.
+- Add a shorter smoke-test path for the GKE integration workflow.


### PR DESCRIPTION
## Summary

- Add a tiny TODO follow-up for a shorter GKE smoke-test path.

## Why

This is a deliberately small PR to exercise the label-triggered GKE integration workflow after PR #117 merged the scheduling and teardown fixes.

## Validation

- git diff --check